### PR TITLE
Enable deployment to clojars

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Install dependencies
       run: clojure -A:test -P
     - name: Run tests
-      run: clojure -X:test
+      run: clojure -T:build ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache
 .cpcache
 .clj-kondo
+target

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,61 @@
+(ns build
+  (:refer-clojure :exclude [test])
+  (:require
+   [cemerick.pomegranate.aether :as aether]
+   [clojure.tools.build.api :as b]))
+
+(def lib 'mrroman/memocks)
+(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+
+(defn test "Run all the tests."
+  [opts]
+  (let [basis    (b/create-basis {:aliases [:test]})
+        cmds     (b/java-command
+                  {:basis      basis
+                   :main      'clojure.main
+                   :main-args ["-m" "cognitect.test-runner"]})
+        {:keys [exit]} (b/process cmds)]
+    (when-not (zero? exit) (throw (ex-info "Tests failed" {}))))
+  opts)
+
+(defn- jar-opts
+  [opts]
+  (assoc opts
+         :lib lib :version version
+         :jar-file (format "target/%s-%s.jar" lib version)
+         :scm {:tag (str "v" version)}
+         :basis (b/create-basis {})
+         :class-dir class-dir
+         :target "target"
+         :src-dirs ["src"]))
+
+(defn ci "Run the CI pipeline of tests (and build the JAR)."
+  [opts]
+  (test opts)
+  (b/delete {:path "target"})
+  (let [opts (jar-opts opts)]
+    (println "\nWriting pom.xml...")
+    (b/write-pom opts)
+    (println "\nCopying source...")
+    (b/copy-dir {:src-dirs ["src"] :target-dir class-dir})
+    (println "\nBuilding JAR...")
+    (b/jar opts))
+  opts)
+
+(defn install "Install the JAR locally."
+  [opts]
+  (let [opts (jar-opts opts)]
+    (b/install opts))
+  opts)
+
+(defn deploy "Deploy the JAR to Clojars."
+  [opts]
+  (let [{:keys [jar-file] :as opts} (jar-opts opts)]
+    (aether/deploy :coordinates [lib version]
+                   :jar-file (b/resolve-path jar-file)
+                   :pom-file (b/pom-path (select-keys opts [:lib :class-dir]))
+                   :repository {"clojars" {:url "https://repo.clojars.org"
+                                           :username (System/getenv "CLOJARS_USERNAME")
+                                           :password (System/getenv "CLOJARS_PASSWORD")}}))
+  opts)

--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,8 @@
 
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
-                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                  :main-opts ["-m" "cognitect.test-runner"]
-                  :exec-fn cognitect.test-runner.api/test}}}
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.5" :git/sha "2a21b7a"}
+                          clj-commons/pomegranate {:git/url "https://github.com/clj-commons/pomegranate.git"
+                                                   :git/sha "4db42b2091f363bff48cbb80bc5230c3afa598d9"}}
+                   :ns-default build}}}


### PR DESCRIPTION
I've used tools.build to call test runner, create jar and pom file. The deployment is manual process now and uses pomegranate to execute the process.