### PR TITLE
Instrument mock with Malli schema defined for target mocked function

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,38 @@ Let's mock function http/get.
 
 Memocks uses `with-redefs` macro provided by Clojure.
 
+### Malli support
+
+Memocks supports Malli function schemas. You can create a mock function instrumented
+with malli based on schema of a function. E.g.
+
+```clj
+(require '[malli.core :as m])
+
+(m/=> my-inc [:=> [:cat :int] :int])
+(defn my-inc [x]
+  (inc x))
+
+;; You have to provide a symbol of function 
+;; or with or without namespace (aliases are supported).
+(def my-inc-mock (mock-fn 'my-inc 1))
+
+(my-inc-mock 0)
+;=> 1
+
+(my-inc-mock "aa")
+;=> An exception ::invalid-input
+
+(def my-inc-mock2 (mock-fn 'my-inc nil))
+(my-inc-mock2 1)
+;=> An exception ::invalid-output
+```
+
+If you use `with-mocks` macro, it will our of the box.
+
+> If you use :malli/schema metadata to define schema, you have to use dev/start!
+> to enable mock instrumentation.
+
 ## License
 
 Copyright © 2016 Konrad Mrożek

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,8 @@
 
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
-                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                               metosin/malli {:mvn/version "0.8.9"}}}
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.5" :git/sha "2a21b7a"}
                           clj-commons/pomegranate {:git/url "https://github.com/clj-commons/pomegranate.git"
                                                    :git/sha "4db42b2091f363bff48cbb80bc5230c3afa598d9"}}


### PR DESCRIPTION
It is common that we want to mock a function, but also test if mock result is valid according to the schema of function that we want to mock. The task is to support instrumenting mock functions for schemas defined with Malli.

This instrumentation is going to be applied only when you use with-mocks macro.