### PR TITLE
New optional second arg to invoked? checks the number of invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Checking if the call happened can be cumbersome, so I've implemented a couple of
 (memocks/invoked? m)
 => true
 
+(memocks/invoked? m 3)
+=> true
+
+(memocks/invoked? m 2)
+=> false
+
 (memocks/invoked-with? m :info "Results:")
 => true
 

--- a/src/com/siili/memocks.clj
+++ b/src/com/siili/memocks.clj
@@ -32,9 +32,9 @@
   (empty? (all-args m)))
 
 (defn invoked?
-  "Checks if mock was ever invoked."
-  [m]
-  (not (not-invoked? m)))
+  "Checks if mock was invoked at least once, or N times."
+  ([m] (not (not-invoked? m)))
+  ([m n] (= n (count (all-args m)))))
 
 (defn invoked-with?
   "Checks if mock was invoked with given args"

--- a/test/com/siili/memocks_test.clj
+++ b/test/com/siili/memocks_test.clj
@@ -30,6 +30,15 @@
       (m1 1)
       (is (memocks/invoked? m1))
       (is (not (memocks/invoked? m2)))))
+  (testing "mock was invoked n times"
+    (let [m1 (memocks/mock)
+          m2 (memocks/mock)]
+      (m1 1)
+      (m1 2)
+      (m1 3)
+      (is (not (memocks/invoked? m1 2)))
+      (is (memocks/invoked? m1 3))
+      (is (not (memocks/invoked? m2)))))
   (testing "mock was invoked with given args"
     (let [m (memocks/mock)]
       (m 3 4 5)


### PR DESCRIPTION
An optional argument to `invoked?` can be provided to check whether the mock was invoked a specified number of times, as opposed to at least once. So far, we have used `(count (all-args m))`.