### PR TITLE
Result function generators for following or matching calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,45 @@ The function takes as an argument a list with all recorded calls.
 
 In this example, mock will return the last call (a list of arguments).
 
+#### The result computing function generators
+
+Memocks provides some result providing function generators.
+
+1. `(memocks/return-values val1 ...)` generates a function returning values in following calls.
+
+```clj
+(def m (memocks/mock (memocks/return-values 1 2 3)))
+
+(m)
+=> 1
+
+(m)
+=> 2
+
+(m)
+=> 3
+```
+
+If there are no more values it throws an exception.
+
+2. `(memocks/return-matching call1 val1 call2 val2 ...)` generator a function returning values 
+for matching calls. You can provide a default value for non-matching call with `:com.silli.memocks/default`.
+
+```clj
+(def m (memocks/mock (memocks/return-matching [:a :b] 1 [:c] 2 ::memocks/default 3)))
+
+(m :a :b)
+=> 1
+
+(m :c)
+=> 2
+
+(m :d)
+=> 3
+```
+
+If there's no matching call, it throws an exception.
+
 ### Mocking symbols
 
 Memocks provides a convenient macro that allows you to mock functions easily.

--- a/src/com/siili/memocks.clj
+++ b/src/com/siili/memocks.clj
@@ -26,6 +26,28 @@
   [m]
   (last (all-args m)))
 
+(defn return-values
+  "Returns a function generating returning values in a following calls."
+  [& values]
+  (comp (vec values) dec count))
+
+(defn return-matching
+  "Returns a function generating returning values matching calls"
+  [& call-value-pairs]
+  (let [call->value (into {}
+                          (partition-all 2)
+                          call-value-pairs)]
+    (fn [args]
+      (cond
+        (contains? call->value (last args))
+        (get call->value (last args))
+
+        (contains? call->value ::default)
+        (get call->value ::default)
+
+        :else
+        (throw (ex-info "No matching call" {:call (last args)}))))))
+
 (defn not-invoked?
   "Checks if mock was never invoked."
   [m]

--- a/test/com/siili/memocks_test.clj
+++ b/test/com/siili/memocks_test.clj
@@ -61,7 +61,23 @@
       (m 2)
       (m 3)
       (is (= (m 4) 5))
-      (is (= [nil '(1) '(2) '(3) '(4)] (memocks/all-args m))))))
+      (is (= [nil '(1) '(2) '(3) '(4)] (memocks/all-args m)))))
+  (testing "mock returning values"
+    (let [m (memocks/mock (memocks/return-values 1 2 3))]
+      (is (= (m) 1))
+      (is (= (m) 2))
+      (is (= (m) 3))
+      (is (thrown? IndexOutOfBoundsException (m)))))
+  (testing "mock returning values for matching call"
+    (testing "with default value"
+      (let [m (memocks/mock (memocks/return-matching [:a :b] 1 [:c] 2 ::memocks/default 3))]
+        (is (= (m :a :b) 1))
+        (is (= (m :c) 2))
+        (is (= (m :d) 3))))
+    (testing "without default value"
+      (let [m (memocks/mock (memocks/return-matching [:a :b] 1))]
+        (is (= (m :a :b) 1))
+        (is (thrown? clojure.lang.ExceptionInfo (m :d)))))))
 
 (defn test-func []
   :original)


### PR DESCRIPTION
This commit adds return-values and return-matching function generators. It simplifies creating mocks

- returning values for following calls
- returning values for matching calls